### PR TITLE
Added a warning regarding production sites.

### DIFF
--- a/head.js
+++ b/head.js
@@ -4,6 +4,7 @@
 	copyright: "tipiirai" / Tero Piirainen
 	license: MIT
 */
+console.log("This is an alpha build - do NOT use it on a production site");
 (function(doc) {
 	
 	var html = doc.documentElement,


### PR DESCRIPTION
I've added a warning message to the top of the script regarding production sites. It will add a message to the user's web inspector, notifying them that it is an alpha build, and should not be used in production.
