### PR TITLE
Multistage loading

### DIFF
--- a/src/load.js
+++ b/src/load.js
@@ -57,7 +57,33 @@
 		
 		return api;		 
 	};
-	
+
+	api.stage = function(stages, callback) {
+		var stagePhase = -1;
+		var stageLoaded = 0;
+		var nextStage = function() {
+			if (++stagePhase >= stages.length) {
+				return callback && callback();
+			}
+			stageLoaded = 0;
+			var stageDef = stages[stagePhase];
+			if (typeof stageDef == 'string') {
+				api.js(stageDef, nextStage);
+				return;
+			}
+			if (stageDef.length === 0) {
+				return nextStage();
+			}
+			for (var i = 0; i < stageDef.length; i++) {
+				api.js(stageDef[i], stageReady);
+			}
+		};
+		var stageReady = function() {
+			if (++stageLoaded == stages[stagePhase].length) { nextStage(); }
+		};
+		nextStage();
+	};
+
 	api.ready = function(key, fn) {
 		
 		var script = scripts[key];


### PR DESCRIPTION
Hi,

The following patch addes the ability for multistage or phase based loading.

Input: Array of phases (phase == Array of filenames), callback

Example:

head.stage([
    ['js/goog/base.js'], // phase 0
    ['js/goog/i18n.datetimesymbols.js',...,'js/goog/useragent.jscript.js'], // phase 1
    ....
    ['js/goog/debug.console.js','js/goog/ui.datepicker.js'] // phase 10
],
function(){head.js('js/libs/openlayers/OpenLayers.js','js/rm/index.js');} // payload
);

It would be very cool if head.js could include s.th. like this.
The actual fun in phase loading is the independence of inner-phase files. They can thus be loaded in parallel and executed in random order, while phases need to run in sequence.
