### PR TITLE
Accept array of scripts as named bundle

### DIFF
--- a/src/load.js
+++ b/src/load.js
@@ -251,23 +251,34 @@
 
 
 	function scriptTag(src, callback)  {
-		
-		var s = doc.createElement('script');		
-		s.type = 'text/' + (src.type || 'javascript');
-		s.src = src.src || src;
-		s.async = false;
-		
-		s.onreadystatechange = s.onload = function() {
-			
-			var state = s.readyState;
-			
-			if (!callback.done && (!state || /loaded|complete/.test(state))) {
-				callback();
-				callback.done = true;
+		if(src instanceof Array) {
+			for(n in src) {
+				var callbacks = 0;
+				scriptTag(src[n], function() {
+					callbacks++;
+					if(callbacks == src.length) {
+						callback();
+					}
+				});
 			}
-		}; 
-		
-		head.appendChild(s); 
+		} else {
+			var s = doc.createElement('script');		
+			s.type = 'text/' + (src.type || 'javascript');
+			s.src = src.src || src;
+			s.async = false;
+
+			s.onreadystatechange = s.onload = function() {
+
+				var state = s.readyState;
+
+				if (!callback.done && (!state || /loaded|complete/.test(state))) {
+					callback();
+					callback.done = true;
+				}
+			}; 
+
+			head.appendChild(s);
+		}
 	}
 	
 	

--- a/test/load.html
+++ b/test/load.html
@@ -8,18 +8,18 @@
 
 	<script> 	
 	head.js(
-		{a: "https://github.com/DmitryBaranovskiy/raphael/raw/master/raphael.js"},
-		{b: "https://github.com/jquery/jquery-ui/raw/master/jquery-1.4.4.js"},
+		{a: ["https://github.com/DmitryBaranovskiy/raphael/raw/master/raphael.js", "https://github.com/janl/mustache.js/raw/master/mustache.js"]},
+		{b: ["https://github.com/jquery/jquery-ui/raw/master/jquery-1.4.4.js", "https://github.com/janl/mustache.js/raw/master/mustache.js"]},
 		{c: "https://github.com/kosmas58/compass-jquery-plugin/raw/master/lib/jslint.js"}, function()  {
-			console.info("a, b & c");	
+			console.info("a, b & c: " + (!!Raphael && !!Mustache && !!JSLINT && !!jQuery));	
 		});
 	
 	head.ready("a", function() {				
-		console.info("a: " + !!Raphael);		
+		console.info("a: " + (!!Raphael && !!Mustache));		
 	});
 	
 	head.ready("b", function() {						
-		console.info("b: "  + !!jQuery);		
+		console.info("b: "  + !!jQuery);
 	});
 	
 	head.ready("c", function() {
@@ -27,7 +27,7 @@
 	});
 	
 	head.ready(function() {				
-		console.info("all");		
+		console.info("all: " + (!!Raphael && !!Mustache && !!JSLINT && !!jQuery));		
 	});
 	
 	head.js("server.js", function() {


### PR DESCRIPTION
This commits adds support for bundling multiple scripts under the same name:

<pre>
head.js({bundle: ['/js/script1.js', '/js/script2.js']}, function() { alert('1 and 2 loaded'); });
head.ready('bundle', function() { alert('1 and 2 loaded'); });
</pre>
