### PR TITLE
'existing' script

### DIFF
--- a/src/load.js
+++ b/src/load.js
@@ -149,7 +149,7 @@
 		}
 
 		var existing = scripts[script.name];
-		if (existing) { return existing; }
+		if (existing && script.url === existing.url) { return existing; }
 		
 		// same URL?
 		for (var name in scripts) {


### PR DESCRIPTION
Hi,

I experienced a weird behavior while loading different scripts like `/foo/index.js`, `/bar/index.js` where head.js was considering `/bar/index.js` was already loaded (whereas it was a totally different script).

After a quick debug, I noticed head.js was only checking for the name in order to decide if a script was `(`not`)?`already loaded.

Here is a quick patch which ensure path is also the same.

Cheers.
