### PR TITLE
exact css selectors for ie

### DIFF
--- a/dist/head.js
+++ b/dist/head.js
@@ -91,7 +91,9 @@
 		
 		// IE versions
 		for (var ver = 3; ver < 11; ver++) {
-			if (parseFloat(ua[2]) < ver) { pushClass("lt-ie" + ver); }			
+			if (parseFloat(ua[2]) < ver) { pushClass("lt-ie" + ver); }
+
+			pushClass("ie" + ver);
 		}
 	} 
 	

--- a/src/core.js
+++ b/src/core.js
@@ -92,6 +92,7 @@
 		// IE versions
 		for (var ver = 3; ver < 11; ver++) {
 			if (parseFloat(ua[2]) < ver) { pushClass("lt-ie" + ver); }			
+			pushClass("ie" + ver);
 		}
 	} 
 	


### PR DESCRIPTION
It was stated in the documentation that they should work like this but I can't make it works, or find some code for those css selectors.

/\* CSS fixes for IE6 */
.ie6 ul  { list-style: none; }
