### PR TITLE
Fix bug with callback with activating in FF

### DIFF
--- a/src/load.js
+++ b/src/load.js
@@ -208,8 +208,8 @@
 		var loaded = false,
 			 count = 0;
 		
-		for (var name in els) {
-			if (els[name].state != LOADED) { return false; }
+		for(var i = 0, l = els.length; i < l; ++i) {
+			if (els[i].state != LOADED) { return false; }
 			loaded = true;
 			count++;
 		}


### PR DESCRIPTION
This should allows FF to execute the provided callback when passed to head.js. Using the for-in look will end up looking at other properties of the array which are not really the resource we are trying to load. Since it is an array, looking at it via its numeric index should fixes the problem.
