### PR TITLE
Changing klass.push() to klass[klass.length]

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -36,7 +36,7 @@
 	}
 
 	function each(arr, fn) {	
-		for (var i = 0; i < arr.length; i++) {
+		for (var i = 0, arr_length = arr.length; i < arr_length; i++) {
 			fn.call(arr, arr[i], i);
 		}
 	}


### PR DESCRIPTION
Changing klass.push() to klass[klass.length] in pushClass() yields 90% better performance in !V8 browsers.

http://jsperf.com/push-vs-lengthf00
