### PR TITLE
Found, reported and fixed a problem in allLoaded with augmented objects.

### DIFF
--- a/src/load.js
+++ b/src/load.js
@@ -209,7 +209,7 @@
 			 count = 0;
 		
 		for (var name in els) {
-			if (els[name].state != LOADED) { return false; }
+			if (els.hasOwnProperty(name) && els[name].state != LOADED) { return false; }
 			loaded = true;
 			count++;
 		}


### PR DESCRIPTION
Issue 125. prevent allLoaded() to falsely fail when objects or arrays are augmented.
