### PR TITLE
Prevent loading empty strings

### DIFF
--- a/src/load.js
+++ b/src/load.js
@@ -79,7 +79,7 @@
 
                 // load
                 each(rest, function(el) {
-                    if (!isFunc(el)) {
+                    if (!isFunc(el) && el !=== '') {
                         preload(getScript(el));
                     }
                 });


### PR DESCRIPTION
This will fix loading issues when trying to load an empty string as a url
