### PR TITLE
IE10 fix plus use async=true when requesting one file

### DIFF
--- a/src/load.js
+++ b/src/load.js
@@ -293,7 +293,7 @@
 
             var state = s.readyState;
 
-            if (!callback.done && (!state || /loaded|complete/.test(state))) {
+             if (!callback.done && (!state || (isAsync ? /complete/ : /loaded|complete/).test(state))) {
                 callback.done = true;
                 callback();
             }


### PR DESCRIPTION
IE10 is not ready yet with the execution of the downloaded script when it passes the readyState: "loading". Therefor it will check for readyState: "completed" if a state is provided and the async attribute is supported (IE10 matched that case).

Also added another fix for browsers that support the async attribute. I found that although the scripts are loaded in parallel. The execution is still delayed of a specific script until all other scripts are downloaded. So now, if you request a single JS file, it will set the async attribute to true. So the execution will not wait until other JS files are loaded.

Example:
head.js('a.js');
head.js('b.js', 'c.js'); // b and c do not depend on a. Though c depends on b.

This leaded to a.js being delayed in execution until b.js and c.js where downloaded. Now it will request a.js with async=true, by which it will execute even though b.js and c.js are not downloaded yet.
