### PR TITLE
fix: head.ready not triggered because of wrong asset.state for css

### DIFF
--- a/src/1.0.0/load.js
+++ b/src/1.0.0/load.js
@@ -437,12 +437,18 @@
             ele.href = asset.url;
             
             // fix for browsers which do not fire onload event for stylesheet (e.g. Safari)
-            var cssSize = document.styleSheets.length;
+            var retry = 0;
             var cssLoadInterval = setInterval(function() {
-                if (document.styleSheets.length > cssSize) {
-                    clearInterval(cssLoadInterval);	
-                    process({ "type": "load" });
-                }
+            	if(asset.state === LOADED || retry++ === 100)
+            		return clearInterval(cssLoadInterval);
+            	
+            	for(var i=0;i<document.styleSheets.length;i++) {
+            		var styleSheet = document.styleSheets[i];
+            		if(styleSheet.href === asset.url) {
+            			clearInterval(cssLoadInterval);
+            			process({ "type": "load" });
+            		}
+            	}
             }, 10);
         }
         else {


### PR DESCRIPTION
Some browsers (e.g. Safari) don't fire the onload event for loaded css, so the asset.state will never updated to LOADED. If allLoaded() is called the css assets are in state = LOADING. This PR adds a workaround for this issue without using the img hack (#240)
