### PR TITLE
Avoid "Cannot read property 'state' of undefined" error

### DIFF
--- a/src/1.0.0/load.js
+++ b/src/1.0.0/load.js
@@ -179,7 +179,7 @@
         items = items || assets;
 
         for (var name in items) {
-            if (items.hasOwnProperty(name) && items[name].state !== LOADED) {
+            if (items.hasOwnProperty(name) && items[name] && items[name].state !== LOADED) {
                 return false;
             }
         }


### PR DESCRIPTION
When loading a set of scripts like the following:

``` javascript
head.load([{'test1': 'http://localhost/js/test1.js'}]);
head.ready(['test1'], function(){
  head.load([{'test2': 'http://localhost/js/test2.js'}]);
});
head.ready(['test1','test2'], function(){
  head.load([{'test3': 'http://localhost/js/test3.js'}]);
});
```

an `Uncaught TypeError: Cannot read property 'state' of undefined` error is thrown and the `test3` script is not loaded.

Checking for `items[name]` on line 182 of the loader seems to clear this up.
