### PR TITLE
change head.load api to pass attributes to loaded dom element

### DIFF
--- a/dist/1.0.0/head.load.js
+++ b/dist/1.0.0/head.load.js
@@ -70,8 +70,8 @@
     function toLabel(url) {
         ///<summary>Converts a url to a file label</summary>
         var items = url.split("/"),
-             name = items[items.length - 1],
-             i    = name.indexOf("?");
+            name = items[items.length - 1],
+            i    = name.indexOf("?");
 
         return i !== -1 ? name.substring(0, i) : name;
     }
@@ -142,27 +142,30 @@
         ///<summary>
         /// Assets are in the form of
         /// {
-        ///     name : label,
-        ///     url  : url,
-        ///     state: state
+        ///     name   : label,
+        ///     url    : url,
+        ///     options: options,
+        ///     state  : state
         /// }
         ///</summary>
-        var asset = {};
+        var asset = { options: {} };
 
         if (typeof item === "object") {
             for (var label in item) {
-                if (!!item[label]) {
-                    asset = {
-                        name: label,
-                        url : item[label]
-                    };
+                if (!!item[label] && label !== 'options') {
+                    asset.name = label;
+                    asset.url = item[label];
+                }
+                else if (!!item[label] && label === 'options') {
+                    asset.options = item[label];
                 }
             }
         }
         else {
             asset = {
-                name: toLabel(item),
-                url : item
+                name   : toLabel(item),
+                url    : item,
+                options: {}
             };
         }
 
@@ -433,7 +436,7 @@
                 // release event listeners
                 ele.onload = ele.onreadystatechange = ele.onerror = null;
 
-                // do callback   
+                // do callback
                 callback();
             }
         }
@@ -460,6 +463,7 @@
 
         var ele;
         var ext = getExtension(asset.url);
+        var attributes = asset.options && asset.options.attributes || {};
 
         if (ext === "css") {
             ele      = doc.createElement("link");
@@ -473,12 +477,16 @@
 
             // Set counter to zero
             asset.cssRetries = 0;
-            asset.cssTimeout = win.setTimeout(isCssLoaded, 500);         
+            asset.cssTimeout = win.setTimeout(isCssLoaded, 500);
         }
         else {
             ele      = doc.createElement("script");
             ele.type = "text/" + (asset.type || "javascript");
             ele.src = asset.url;
+        }
+
+        for (var item in attributes) {
+            ele.setAttribute(item, attributes[item]);
         }
 
         ele.onload  = ele.onreadystatechange = process;
@@ -503,7 +511,7 @@
         // use insertBefore to keep IE from throwing Operation Aborted (thx Bryan Forbes!)
         var head = doc.head || doc.getElementsByTagName("head")[0];
 
-        // but insert at end of head, because otherwise if it is a stylesheet, it will not override values      
+        // but insert at end of head, because otherwise if it is a stylesheet, it will not override values
         head.insertBefore(ele, head.lastChild);
     }
 

--- a/src/1.0.0/load.js
+++ b/src/1.0.0/load.js
@@ -141,27 +141,30 @@
         ///<summary>
         /// Assets are in the form of
         /// {
-        ///     name : label,
-        ///     url  : url,
-        ///     state: state
+        ///     name   : label,
+        ///     url    : url,
+        ///     options: options,
+        ///     state  : state
         /// }
         ///</summary>
-        var asset = {};
+        var asset = { options: {} };
 
         if (typeof item === "object") {
             for (var label in item) {
-                if (!!item[label]) {
-                    asset = {
-                        name: label,
-                        url : item[label]
-                    };
+                if (!!item[label] && label !== 'options') {
+                    asset.name = label;
+                    asset.url = item[label];
+                }
+                else if (!!item[label] && label === 'options') {
+                    asset.options = item[label];
                 }
             }
         }
         else {
             asset = {
-                name: toLabel(item),
-                url : item
+                name   : toLabel(item),
+                url    : item,
+                options: {}
             };
         }
 
@@ -432,7 +435,7 @@
                 // release event listeners
                 ele.onload = ele.onreadystatechange = ele.onerror = null;
 
-                // do callback   
+                // do callback
                 callback();
             }
         }
@@ -459,6 +462,7 @@
 
         var ele;
         var ext = getExtension(asset.url);
+        var attributes = asset.options && asset.options.attributes || {};
 
         if (ext === "css") {
             ele      = doc.createElement("link");
@@ -472,12 +476,16 @@
 
             // Set counter to zero
             asset.cssRetries = 0;
-            asset.cssTimeout = win.setTimeout(isCssLoaded, 500);         
+            asset.cssTimeout = win.setTimeout(isCssLoaded, 500);
         }
         else {
             ele      = doc.createElement("script");
             ele.type = "text/" + (asset.type || "javascript");
             ele.src = asset.url;
+        }
+
+        for (var item in attributes) {
+            ele.setAttribute(item, attributes[item]);
         }
 
         ele.onload  = ele.onreadystatechange = process;
@@ -502,7 +510,7 @@
         // use insertBefore to keep IE from throwing Operation Aborted (thx Bryan Forbes!)
         var head = doc.head || doc.getElementsByTagName("head")[0];
 
-        // but insert at end of head, because otherwise if it is a stylesheet, it will not override values      
+        // but insert at end of head, because otherwise if it is a stylesheet, it will not override values
         head.insertBefore(ele, head.lastChild);
     }
 

--- a/test/unit/1.0.0/test.load.js
+++ b/test/unit/1.0.0/test.load.js
@@ -209,3 +209,19 @@ asyncTest("test(bool, [ { label: jsFilePath }, { label: jsFilePath } ], [ { labe
             start();
     });
 });
+
+asyncTest("load( {label: jsFilePath, options: { attributes: { data-main: \"loaded1\"} } }, callback)", 1, function(assert) {
+   head
+       .load({
+           label: libs.jquery(),
+           options: {
+               attributes: {
+                   "data-main": "loaded1"
+               }
+           }
+       },function() {
+           ok(jQuery("script[data-main='loaded1']").length === 1, "Loaded with attribute data-main");
+
+           start();
+       });
+});


### PR DESCRIPTION
As mentioned in #312  I would like to load a CSS file with media="print" attribute.
This PR is inspired by @robert-hoffmann  comments in https://github.com/headjs/headjs/issues/262#issuecomment-26493353 and in https://github.com/headjs/headjs/issues/267#issuecomment-27417241

It is now possible to add options to an asset. Implemented are additional attributes to the created DOM elements (link or script).

```
head.load({
           mylabel: "somescriptPath",
            options: {
                attributes: {
                    "data-main": "loaded1"
                }
            }
        },
       callback
);
```

I could not find any script to create the dist files, is there one?
