### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 [![Head JS](http://headjs.com/site/assets/img/logo-big.png)](http://headjs.com)
 
-###Latest Version: v1.0.3 :: [Downloads](http://headjs.com/site/download.html) | [Docs](http://headjs.com/site/api/v1.00.html) | [News](http://headjs.com/site/blog.html) | [Intro](http://headjs.com)
+### Latest Version: v1.0.3 :: [Downloads](http://headjs.com/site/download.html) | [Docs](http://headjs.com/site/api/v1.00.html) | [News](http://headjs.com/site/blog.html) | [Intro](http://headjs.com)
 
-#####Status
+##### Status
 [![Build Status](https://travis-ci.org/headjs/headjs.png?branch=master)](https://travis-ci.org/headjs/headjs)
 
 
-#####Tested with (..amongst others)
+##### Tested with (..amongst others)
 [![Selenium Status](https://saucelabs.com/browser-matrix/itechnology.svg)](https://saucelabs.com/u/itechnology)
 
 
-###Responsive Design, Feature Detections, and Resource Loading
+### Responsive Design, Feature Detections, and Resource Loading
   * Speed up your apps: Load JS & CSS asyncronously and in parallel, but execute them in order
   * Load one asset if a condition is met, else fallback and load a different one
   * Manage script dependencies, and execute callbacks once they are loaded
@@ -28,7 +28,7 @@
     * ___A concise solution to universal problems___
 
 
-###Resources
+### Resources
 - __WebSite__
   - [http://headjs.com](http://headjs.com)
 - __Bugs__

--- a/_posts/2013-05-20-Migrating-to-Jekyll.md
+++ b/_posts/2013-05-20-Migrating-to-Jekyll.md
@@ -5,7 +5,7 @@ excerpt: Now testing Jekyll for static stite generation, including blog & commen
 scripts: ["/site/assets/libs/jquery/jquery.min.js", "https://cdn.moot.it/latest/moot.min.js", "/site/assets/js/comments.min.js"]
 ---
 
-#{{ page.title }} ({{ page.date | date_to_string }})
+# {{ page.title }} ({{ page.date | date_to_string }})
 
 <hr />
 

--- a/_posts/2013-11-04-HeadJS-v1.0.0-Released.md
+++ b/_posts/2013-11-04-HeadJS-v1.0.0-Released.md
@@ -5,7 +5,7 @@ excerpt: Yes, it's finally out ! Adding a few new features, and a few fixes.
 scripts: ["/site/assets/libs/jquery/jquery.min.js", "https://cdn.moot.it/latest/moot.min.js", "/site/assets/js/comments.min.js"]
 ---
 
-#{{ page.title }} ({{ page.date | date_to_string }})
+# {{ page.title }} ({{ page.date | date_to_string }})
 
 <hr />
 

--- a/_posts/2013-11-05-HeadJS-v1.0.1-Update.md
+++ b/_posts/2013-11-05-HeadJS-v1.0.1-Update.md
@@ -5,7 +5,7 @@ excerpt: Small point release to patch a bug that had a fix but got missed
 scripts: ["/site/assets/libs/jquery/jquery.min.js", "https://cdn.moot.it/latest/moot.min.js", "/site/assets/js/comments.min.js"]
 ---
 
-#{{ page.title }} ({{ page.date | date_to_string }})
+# {{ page.title }} ({{ page.date | date_to_string }})
 
 <hr />
 

--- a/_posts/2013-11-08-head.responsive-v2.0.0-alpha.md
+++ b/_posts/2013-11-08-head.responsive-v2.0.0-alpha.md
@@ -5,7 +5,7 @@ excerpt: Getting things ready for 2.0, and looking for feedback
 scripts: ["/site/assets/libs/jquery/jquery.min.js", "https://cdn.moot.it/latest/moot.min.js", "/site/assets/js/comments.min.js"]
 ---
 
-#{{ page.title }} ({{ page.date | date_to_string }})
+# {{ page.title }} ({{ page.date | date_to_string }})
 
 <hr />
 

--- a/_posts/2013-11-13-HeadJS-v1.0.2-Update.md
+++ b/_posts/2013-11-13-HeadJS-v1.0.2-Update.md
@@ -5,7 +5,7 @@ excerpt: Small point release
 scripts: ["/site/assets/libs/jquery/jquery.min.js", "https://cdn.moot.it/latest/moot.min.js", "/site/assets/js/comments.min.js"]
 ---
 
-#{{ page.title }} ({{ page.date | date_to_string }})
+# {{ page.title }} ({{ page.date | date_to_string }})
 
 <hr />
 

--- a/_posts/2013-11-22-HeadJS-v1.0.3-Update.md
+++ b/_posts/2013-11-22-HeadJS-v1.0.3-Update.md
@@ -5,7 +5,7 @@ excerpt: Small point release
 scripts: ["/site/assets/libs/jquery/jquery.min.js", "https://cdn.moot.it/latest/moot.min.js", "/site/assets/js/comments.min.js"]
 ---
 
-#{{ page.title }} ({{ page.date | date_to_string }})
+# {{ page.title }} ({{ page.date | date_to_string }})
 
 <hr />
 

--- a/dist/0.97a/README.md
+++ b/dist/0.97a/README.md
@@ -1,17 +1,17 @@
-#Prepackaged Files
+# Prepackaged Files
 
-###head.js / head.min.js
+### head.js / head.min.js
 
  - Complete package containing: core.js, css3.js, and load.js
 
-###head.css3.js / head.css3.min.js
+### head.css3.js / head.css3.min.js
 
  - Package containing: core.js and css3.js
 
-###head.core.js / head.core.min.js
+### head.core.js / head.core.min.js
 
  - Package containing only core.js
 
-###head.load.js / head.load.min.js
+### head.load.js / head.load.min.js
 
  - Package containing only load.js

--- a/dist/0.98/README.md
+++ b/dist/0.98/README.md
@@ -1,17 +1,17 @@
-#Prepackaged Files
+# Prepackaged Files
 
-###head.js / head.min.js
+### head.js / head.min.js
 
  - Complete package containing: core.js, css3.js, and load.js
 
-###head.css3.js / head.css3.min.js
+### head.css3.js / head.css3.min.js
 
  - Package containing: core.js and css3.js
 
-###head.core.js / head.core.min.js
+### head.core.js / head.core.min.js
 
  - Package containing only core.js
 
-###head.load.js / head.load.min.js
+### head.load.js / head.load.min.js
 
  - Package containing only load.js

--- a/dist/0.99/README.md
+++ b/dist/0.99/README.md
@@ -1,25 +1,25 @@
-##Prepackaged Files
+## Prepackaged Files
 
-###Full: Responsive Design + Feature Detections + Asset Loader
-####head.js / head.min.js
+### Full: Responsive Design + Feature Detections + Asset Loader
+#### head.js / head.min.js
 
  - Contains: core.js, css3.js, and load.js
  - For Debug: head.min.js.map ([js source map](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/))
 
-###Bundle: Responsive Design + Feature Detections
-####head.css3.js / head.css3.min.js
+### Bundle: Responsive Design + Feature Detections
+#### head.css3.js / head.css3.min.js
 
  - Contains: core.js and css3.js
  - For Debug: head.css3.min.js.map ([js source map](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/))
 
-###Bundle: Responsive Design
-####head.core.js / head.core.min.js
+### Bundle: Responsive Design
+#### head.core.js / head.core.min.js
 
  - Contains: core.js
  - For Debug: head.core.min.js.map ([js source map](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/))
 
-###Bundle: Asset Loader
-####head.load.js / head.load.min.js
+### Bundle: Asset Loader
+#### head.load.js / head.load.min.js
 
  - Contains: load.js
  - For Debug: head.load.min.js.map ([js source map](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/))

--- a/dist/1.0.0/README.md
+++ b/dist/1.0.0/README.md
@@ -1,25 +1,25 @@
-##Prepackaged Files
+## Prepackaged Files
 
-###Full: Responsive Design + Feature Detections + Asset Loader
-####head.js / head.min.js
+### Full: Responsive Design + Feature Detections + Asset Loader
+#### head.js / head.min.js
 
  - Contains: core.js, css3.js, and load.js
  - For Debug: head.min.js.map ([js source map](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/))
 
-###Bundle: Responsive Design + Feature Detections
-####head.css3.js / head.css3.min.js
+### Bundle: Responsive Design + Feature Detections
+#### head.css3.js / head.css3.min.js
 
  - Contains: core.js and css3.js
  - For Debug: head.css3.min.js.map ([js source map](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/))
 
-###Bundle: Responsive Design
-####head.core.js / head.core.min.js
+### Bundle: Responsive Design
+#### head.core.js / head.core.min.js
 
  - Contains: core.js
  - For Debug: head.core.min.js.map ([js source map](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/))
 
-###Bundle: Asset Loader
-####head.load.js / head.load.min.js
+### Bundle: Asset Loader
+#### head.load.js / head.load.min.js
 
  - Contains: load.js
  - For Debug: head.load.min.js.map ([js source map](http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/))

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,17 +1,17 @@
-#Prepackaged Files
+# Prepackaged Files
 
-###head.js / head.min.js
+### head.js / head.min.js
 
  - Complete package containing: core.js, css3.js, and load.js
 
-###head.css3.js / head.css3.min.js
+### head.css3.js / head.css3.min.js
 
  - Package containing: core.js and css3.js
 
-###head.core.js / head.core.min.js
+### head.core.js / head.core.min.js
 
  - Package containing only core.js
 
-###head.load.js / head.load.min.js
+### head.load.js / head.load.min.js
 
  - Package containing only load.js


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
