### PR TITLE
docs: Fix simple typo, existant -> existent

### DIFF
--- a/dist/0.98/head.js
+++ b/dist/0.98/head.js
@@ -771,7 +771,7 @@
             };
         }
 
-        // is the item already existant
+        // is the item already existent
         var existing = scripts[script.name];
         if (existing && existing.url === script.url) {
             return existing;

--- a/dist/0.98/head.load.js
+++ b/dist/0.98/head.load.js
@@ -313,7 +313,7 @@
             };
         }
 
-        // is the item already existant
+        // is the item already existent
         var existing = scripts[script.name];
         if (existing && existing.url === script.url) {
             return existing;

--- a/dist/0.99/head.js
+++ b/dist/0.99/head.js
@@ -780,7 +780,7 @@
             };
         }
 
-        // is the item already existant
+        // is the item already existent
         var existing = assets[asset.name];
         if (existing && existing.url === asset.url) {
             return existing;

--- a/dist/0.99/head.load.js
+++ b/dist/0.99/head.load.js
@@ -314,7 +314,7 @@
             };
         }
 
-        // is the item already existant
+        // is the item already existent
         var existing = assets[asset.name];
         if (existing && existing.url === asset.url) {
             return existing;

--- a/dist/1.0.0/head.js
+++ b/dist/1.0.0/head.js
@@ -643,7 +643,7 @@
             };
         }
 
-        // is the item already existant
+        // is the item already existent
         var existing = assets[asset.name];
         if (existing && existing.url === asset.url) {
             return existing;

--- a/dist/1.0.0/head.load.js
+++ b/dist/1.0.0/head.load.js
@@ -166,7 +166,7 @@
             };
         }
 
-        // is the item already existant
+        // is the item already existent
         var existing = assets[asset.name];
         if (existing && existing.url === asset.url) {
             return existing;

--- a/src/0.98/load.js
+++ b/src/0.98/load.js
@@ -313,7 +313,7 @@
             };
         }
 
-        // is the item already existant
+        // is the item already existent
         var existing = scripts[script.name];
         if (existing && existing.url === script.url) {
             return existing;

--- a/src/0.99/load.js
+++ b/src/0.99/load.js
@@ -313,7 +313,7 @@
             };
         }
 
-        // is the item already existant
+        // is the item already existent
         var existing = assets[asset.name];
         if (existing && existing.url === asset.url) {
             return existing;

--- a/src/1.0.0/load.js
+++ b/src/1.0.0/load.js
@@ -165,7 +165,7 @@
             };
         }
 
-        // is the item already existant
+        // is the item already existent
         var existing = assets[asset.name];
         if (existing && existing.url === asset.url) {
             return existing;

--- a/src/2.0.0/load.js
+++ b/src/2.0.0/load.js
@@ -170,7 +170,7 @@
             };
         }
 
-        // is the item already existant
+        // is the item already existent
         var existing = assets[asset.name];
         if (existing && existing.url === asset.url) {
             return existing;


### PR DESCRIPTION
There is a small typo in dist/0.98/head.js, dist/0.98/head.load.js, dist/0.99/head.js, dist/0.99/head.load.js, dist/1.0.0/head.js, dist/1.0.0/head.load.js, src/0.98/load.js, src/0.99/load.js, src/1.0.0/load.js, src/2.0.0/load.js.

Should read `existent` rather than `existant`.

